### PR TITLE
Fix for jackson serialization

### DIFF
--- a/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
+++ b/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
@@ -192,7 +192,7 @@ public class ResourceBundleMessageInterpolator implements MessageInterpolator {
         public Object toSpecification(GraphQLError error) {
             Map<String, Object> map = new LinkedHashMap<>();
             map.put("type", "ExtendedValidationError");
-            map.put("validatedPath", fieldOrArgumentPath);
+            map.put("validatedPath", fieldOrArgumentPath.toString());
             if (directive != null) {
                 map.put("constraint", "@" + directive.getName());
             }


### PR DESCRIPTION
When jackson tries to serialize the graphql error I get the following exception:
`java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Direct self-reference leading to cycle (through reference chain: java.util.LinkedHashMap["errors"]->java.util.ArrayList[0]->java.util.LinkedHashMap["extensions"]->java.util`