### PR TITLE
Support Graphql v14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:13.0"
+    compile "com.graphql-java:graphql-java:14.0"
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile "javax.validation:validation-api:2.0.1.Final"
     compile "org.hibernate.validator:hibernate-validator:6.0.17.Final"

--- a/src/main/java/graphql/validation/constraints/AbstractDirectiveConstraint.java
+++ b/src/main/java/graphql/validation/constraints/AbstractDirectiveConstraint.java
@@ -10,6 +10,7 @@ import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLNamedInputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLTypeUtil;
 import graphql.validation.rules.ValidationEnvironment;
@@ -162,7 +163,7 @@ public abstract class AbstractDirectiveConstraint implements DirectiveConstraint
      * @return true ifits oneof them
      */
     protected boolean isOneOfTheseTypes(GraphQLInputType inputType, GraphQLScalarType... scalarTypes) {
-        GraphQLInputType unwrappedType = Util.unwrapNonNull(inputType);
+        GraphQLNamedInputType unwrappedType = Util.unwrapNonNullNamedType(inputType);
         for (GraphQLScalarType scalarType : scalarTypes) {
             if (unwrappedType.getName().equals(scalarType.getName())) {
                 return true;

--- a/src/main/java/graphql/validation/util/Util.java
+++ b/src/main/java/graphql/validation/util/Util.java
@@ -6,6 +6,7 @@ import graphql.Internal;
 import graphql.execution.DataFetcherResult;
 import graphql.execution.ExecutionPath;
 import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLNamedInputType;
 import graphql.schema.GraphQLType;
 import graphql.schema.GraphQLTypeUtil;
 
@@ -34,6 +35,16 @@ public class Util {
         type = GraphQLTypeUtil.unwrapNonNull(type);
         if (type instanceof GraphQLInputType) {
             return (GraphQLInputType) type;
+        } else {
+            String argType = GraphQLTypeUtil.simplePrint(inputType);
+            return Assert.assertShouldNeverHappen("You have a wrapped type that is in fact not a input type : %s", argType);
+        }
+    }
+
+    public static GraphQLNamedInputType unwrapNonNullNamedType(GraphQLInputType inputType) {
+        GraphQLType type = GraphQLTypeUtil.unwrapNonNull(inputType);
+        if (type instanceof GraphQLNamedInputType) {
+            return (GraphQLNamedInputType) type;
         } else {
             String argType = GraphQLTypeUtil.simplePrint(inputType);
             return Assert.assertShouldNeverHappen("You have a wrapped type that is in fact not a input type : %s", argType);


### PR DESCRIPTION
Changes the graphql version to 14. Fixes the BC break that resulted in a
compilation failure. I added a new method since tests were failing when
the original Util method was updated to check for GraphQLNamedInputType.