### PR TITLE
Updating to latest hibernate-validation dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile "com.graphql-java:graphql-java:15.0"
     compile 'org.slf4j:slf4j-api:1.7.30'
     compile "jakarta.validation:jakarta.validation-api:2.0.2"
-    compile "org.hibernate.validator:hibernate-validator:6.0.19.Final"
+    compile "org.hibernate.validator:hibernate-validator:6.1.5.Final"
     compile "jakarta.el:jakarta.el-api:3.0.3"
     compile "org.glassfish:jakarta.el:3.0.3"
 

--- a/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
+++ b/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
@@ -7,16 +7,18 @@ import graphql.execution.ExecutionPath;
 import graphql.schema.GraphQLDirective;
 import graphql.validation.el.StandardELVariables;
 import graphql.validation.rules.ValidationEnvironment;
+import javax.validation.Path;
 import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation.ConstraintLocationKind;
 import org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDescriptor;
 import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.LinkedHashMap;
@@ -148,16 +150,18 @@ public class ResourceBundleMessageInterpolator implements MessageInterpolator {
 
         ConstraintDescriptorImpl<BridgeAnnotation> constraintDescriptor
                 = new ConstraintDescriptorImpl<>(
-                new ConstraintHelper(), null,
-                annotationDescriptor, ElementType.FIELD
+                ConstraintHelper.forAllBuiltinConstraints(), null,
+                annotationDescriptor, ConstraintLocationKind.FIELD, ConstraintType.GENERIC
         );
 
         Map<String, Object> expressionVariables = StandardELVariables.standardELVars(validationEnvironment);
 
         Class<?> rootBeanType = null;
+        Path propertyPath = null;
+
         return new MessageInterpolatorContext(
                 constraintDescriptor, validatedValue, rootBeanType,
-                messageParams, expressionVariables);
+                propertyPath, messageParams, expressionVariables);
     }
 
     private org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator hibernateInterpolator() {

--- a/src/test/groovy/ELDiscover.java
+++ b/src/test/groovy/ELDiscover.java
@@ -3,6 +3,8 @@ import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation.ConstraintLocationKind;
 import org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDescriptor;
 import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
 
@@ -14,7 +16,6 @@ import javax.el.ValueExpression;
 import javax.validation.MessageInterpolator;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
-import java.lang.annotation.ElementType;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,10 +89,11 @@ public class ELDiscover {
                 = new ConstraintAnnotationDescriptor.Builder<>(NotNull.class, attributes);
 
         ConstraintDescriptorImpl<NotNull> constraintDescriptor = new ConstraintDescriptorImpl<>(
-                new ConstraintHelper(),
+                ConstraintHelper.forAllBuiltinConstraints(),
                 null,
                 constraintBuilder.build(),
-                ElementType.FIELD
+                ConstraintLocationKind.FIELD,
+                ConstraintType.GENERIC
         );
 
 
@@ -103,7 +105,7 @@ public class ELDiscover {
         PathImpl rootPath = PathImpl.createRootPath();
 
         MessageInterpolator.Context context = new MessageInterpolatorContext(
-                constraintDescriptor, user, null, Collections.emptyMap(), Collections.emptyMap());
+                constraintDescriptor, user, null, rootPath, Collections.emptyMap(), Collections.emptyMap());
 
         print("${validatedValue.age}", messageInterpolator, context);
         print("${validatedValue}", messageInterpolator, context);


### PR DESCRIPTION
Updating to the latest hibernate-validation dependency, 6.1.5.Final (previously using 6.0.19.Final) which is the default version used in spring-boot-starter-parent 2.3.0.RELEASE and above

As an aside note - I had spent 2 days chasing runtime null pointers a few months back because hibernate-validation-6.0.19.Final was being overridden by a newer transitive dependency on my classpath, and there is a breaking change between 6.0.19.Final and 6.1.*