### PR TITLE
fix schema wiring

### DIFF
--- a/src/main/java/graphql/validation/schemawiring/FieldValidatorDataFetcher.java
+++ b/src/main/java/graphql/validation/schemawiring/FieldValidatorDataFetcher.java
@@ -1,0 +1,79 @@
+package graphql.validation.schemawiring;
+
+import graphql.GraphQLError;
+import graphql.schema.*;
+import graphql.validation.interpolation.MessageInterpolator;
+import graphql.validation.rules.OnValidationErrorStrategy;
+import graphql.validation.rules.TargetedValidationRules;
+import graphql.validation.rules.ValidationRule;
+import graphql.validation.rules.ValidationRules;
+import graphql.validation.util.Util;
+
+import java.util.List;
+import java.util.Locale;
+
+public class FieldValidatorDataFetcher implements DataFetcher<Object> {
+    private final OnValidationErrorStrategy errorStrategy;
+    private final MessageInterpolator messageInterpolator;
+    private final DataFetcher<?> defaultDataFetcher;
+    private final Locale defaultLocale;
+    private final ValidationRules validationRules;
+    private TargetedValidationRules applicableRules;
+
+    public FieldValidatorDataFetcher(OnValidationErrorStrategy errorStrategy,
+                                     MessageInterpolator messageInterpolator,
+                                     DataFetcher<?> defaultDataFetcher,
+                                     Locale defaultLocale,
+                                     ValidationRules validationRules) {
+        this.errorStrategy = errorStrategy;
+        this.messageInterpolator = messageInterpolator;
+        this.defaultDataFetcher = defaultDataFetcher;
+        this.defaultLocale = defaultLocale;
+        this.validationRules = validationRules;
+        this.applicableRules = null;
+    }
+
+    @Override
+    public Object get(DataFetchingEnvironment environment) throws Exception {
+        if (!wereApplicableRulesFetched()) {
+            fetchApplicableRules(environment);
+        }
+
+        // When no validation is performed, this data fetcher is a pass-through
+        if (applicableRules.isEmpty()) {
+            return defaultDataFetcher.get(environment);
+        }
+
+        List<GraphQLError> errors = applicableRules.runValidationRules(environment, messageInterpolator, defaultLocale);
+        if (!errors.isEmpty()) {
+            if (!errorStrategy.shouldContinue(errors, environment)) {
+                return errorStrategy.onErrorValue(errors, environment);
+            }
+        }
+
+        Object returnValue = defaultDataFetcher.get(environment);
+        if (errors.isEmpty()) {
+            return returnValue;
+        }
+        return Util.mkDFRFromFetchedResult(errors, returnValue);
+    }
+
+    private void fetchApplicableRules(DataFetchingEnvironment environment) {
+        final GraphQLFieldDefinition field = environment.getFieldDefinition();
+        final GraphQLFieldsContainer container = asContainer(environment);
+
+        applicableRules = validationRules.buildRulesFor(field, container);
+    }
+
+    private GraphQLFieldsContainer asContainer(DataFetchingEnvironment environment) {
+        final GraphQLType parent = environment.getParentType();
+        if (parent == null) {
+            return null;
+        }
+        return (GraphQLFieldsContainer) environment.getParentType();
+    }
+
+    private boolean wereApplicableRulesFetched() {
+        return applicableRules != null;
+    }
+}

--- a/src/main/java/graphql/validation/schemawiring/ValidationSchemaWiring.java
+++ b/src/main/java/graphql/validation/schemawiring/ValidationSchemaWiring.java
@@ -1,6 +1,5 @@
 package graphql.validation.schemawiring;
 
-import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLFieldDefinition;
@@ -11,17 +10,15 @@ import graphql.validation.interpolation.MessageInterpolator;
 import graphql.validation.rules.OnValidationErrorStrategy;
 import graphql.validation.rules.TargetedValidationRules;
 import graphql.validation.rules.ValidationRules;
-import graphql.validation.util.Util;
 
-import java.util.List;
 import java.util.Locale;
 
 /**
- * A {@link graphql.schema.idl.SchemaDirectiveWiring} that can be used to inject validation rules into the data fetchers
+ * A {@link SchemaDirectiveWiring} that can be used to inject validation rules into the data fetchers
  * when the graphql schema is being built.  It will use the validation rules and ask each one of they apply to the field and or its
  * arguments.
  * <p>
- * If there are rules that apply then it will it will change the {@link graphql.schema.DataFetcher} of that field so that rules get run
+ * If there are rules that apply then it will it will change the {@link DataFetcher} of that field so that rules get run
  * BEFORE the original field fetch is run.
  */
 @PublicApi
@@ -38,40 +35,29 @@ public class ValidationSchemaWiring implements SchemaDirectiveWiring {
         GraphQLFieldsContainer fieldsContainer = env.getFieldsContainer();
         GraphQLFieldDefinition fieldDefinition = env.getFieldDefinition();
 
-        TargetedValidationRules rules = ruleCandidates.buildRulesFor(fieldDefinition, fieldsContainer);
-        if (rules.isEmpty()) {
-            return fieldDefinition; // no rules - no validation needed
-        }
-
         OnValidationErrorStrategy errorStrategy = ruleCandidates.getOnValidationErrorStrategy();
         MessageInterpolator messageInterpolator = ruleCandidates.getMessageInterpolator();
         Locale locale = ruleCandidates.getLocale();
 
-        final DataFetcher currentDF = env.getCodeRegistry().getDataFetcher(fieldsContainer, fieldDefinition);
-        final DataFetcher newDF = buildValidatingDataFetcher(rules, errorStrategy, messageInterpolator, currentDF, locale);
+        final DataFetcher<?> currentDF = env.getCodeRegistry().getDataFetcher(fieldsContainer, fieldDefinition);
+        final DataFetcher<?> newDF = buildValidatingDataFetcher(errorStrategy, messageInterpolator, currentDF, locale);
 
         env.getCodeRegistry().dataFetcher(fieldsContainer, fieldDefinition, newDF);
 
         return fieldDefinition;
     }
 
-    private DataFetcher buildValidatingDataFetcher(TargetedValidationRules rules, OnValidationErrorStrategy errorStrategy, MessageInterpolator messageInterpolator, DataFetcher currentDF, final Locale defaultLocale) {
-        // ok we have some rules that need to be applied to this field and its arguments
-        return environment -> {
-            List<GraphQLError> errors = rules.runValidationRules(environment, messageInterpolator, defaultLocale);
-            if (!errors.isEmpty()) {
-                // should we continue?
-                if (!errorStrategy.shouldContinue(errors, environment)) {
-                    return errorStrategy.onErrorValue(errors, environment);
-                }
-            }
-            // we have no validation errors or they said continue so call the underlying data fetcher
-            Object returnValue = currentDF.get(environment);
-            if (errors.isEmpty()) {
-                return returnValue;
-            }
-            return Util.mkDFRFromFetchedResult(errors, returnValue);
-        };
+    private DataFetcher<Object> buildValidatingDataFetcher(OnValidationErrorStrategy errorStrategy,
+                                                           MessageInterpolator messageInterpolator,
+                                                           DataFetcher<?> currentDF,
+                                                           final Locale defaultLocale) {
+        return new FieldValidatorDataFetcher(
+                errorStrategy,
+                messageInterpolator,
+                currentDF,
+                defaultLocale,
+                ruleCandidates
+        );
     }
 
 }


### PR DESCRIPTION
Resolves #17 

As a temporary fix, at least until it is possible to have fields resolved correctly in `onField` of `ValidationSchemaWiring`.

This has the downside to only validate the fields directive parameters on the first call to the graphQL API, which is another problem, because the API will start normally and throw an exception on the first call. It's yours to decide if it's better to fail validation at start, but fail to validate half the queries, or throw an exception on the first call... 