### PR TITLE
Ignore size constraint when value is null

### DIFF
--- a/src/main/java/graphql/validation/constraints/standard/SizeConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/SizeConstraint.java
@@ -45,13 +45,17 @@ public class SizeConstraint extends AbstractDirectiveConstraint {
     @Override
     protected List<GraphQLError> runConstraint(ValidationEnvironment validationEnvironment) {
         Object validatedValue = validationEnvironment.getValidatedValue();
+        
+        if(validatedValue == null) {
+            return Collections.emptyList();
+        }
+
         GraphQLInputType argType = validationEnvironment.getValidatedType();
 
         GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
         int min = getIntArg(directive, "min");
         int max = getIntArg(directive, "max");
-
-
+        
         int size = getStringOrIDOrObjectOrMapLength(argType, validatedValue);
 
         if (size < min) {


### PR DESCRIPTION
- GraphQL's `!` does this validation by default
- This is standard Spring behavior for the `@Size` annotatino