### PR TITLE
(chore) updating graphql-java, hibernate-validator, groovy-all dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 
 dependencies {
-    compile "com.graphql-java:graphql-java:16.1"
+    compile "com.graphql-java:graphql-java:16.2"
     compile 'org.slf4j:slf4j-api:1.7.30'
     compile "jakarta.validation:jakarta.validation-api:2.0.2"
     compile "org.hibernate.validator:hibernate-validator:6.1.6.Final"

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     compile "com.graphql-java:graphql-java:16.2"
     compile 'org.slf4j:slf4j-api:1.7.30'
     compile "jakarta.validation:jakarta.validation-api:2.0.2"
-    compile "org.hibernate.validator:hibernate-validator:6.1.6.Final"
+    compile "org.hibernate.validator:hibernate-validator:6.1.7.Final"
     compile "jakarta.el:jakarta.el-api:3.0.3"
     compile "org.glassfish:jakarta.el:3.0.3"
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     testCompile 'org.slf4j:slf4j-simple:1.7.30'
     testCompile 'org.spockframework:spock-core:1.3-groovy-2.5'
-    testCompile 'org.codehaus.groovy:groovy-all:2.5.11'
+    testCompile 'org.codehaus.groovy:groovy-all:2.5.14'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
- Updating graphql-java to latest
- Updating hibernate-validator to what is in springboot 2.4.3
- Updating groovy-all to match dep used in graphql-java
