### PR TITLE
chore(deps): Updating to use graphql-java 18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ repositories {
 
 
 dependencies {
-    api "com.graphql-java:graphql-java:17.0"
-    api "com.graphql-java:graphql-java-extended-scalars:17.0"
+    api "com.graphql-java:graphql-java:18.0"
+    api "com.graphql-java:graphql-java-extended-scalars:18.0"
     api "org.hibernate.validator:hibernate-validator:7.0.1.Final"
     api "org.glassfish:jakarta.el:4.0.0"
 


### PR DESCRIPTION
Bump dependency from graphql-java:17.0 to graphql-java:18.0.

Has a dependency on https://github.com/graphql-java/graphql-java-extended-scalars/pull/57 being merged and released before the build will pass