### PR TITLE
Pass in the correct value for AbstractDecimalMinMaxConstraint error message

### DIFF
--- a/src/main/java/graphql/validation/constraints/standard/AbstractDecimalMinMaxConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/AbstractDecimalMinMaxConstraint.java
@@ -73,7 +73,7 @@ abstract class AbstractDecimalMinMaxConstraint extends AbstractDirectiveConstrai
 
         if (!isOK) {
             return mkError(validationEnvironment, directive, mkMessageParams(validatedValue, validationEnvironment,
-                    "value", validatedValue,
+                    "value", value,
                     "inclusive", inclusive));
 
         }


### PR DESCRIPTION
Fix #62, backport to `v17.x-validator-6.2.0.Final`