### PR TITLE
Replace to ConcurrentMap from Map

### DIFF
--- a/src/main/java/graphql/validation/constraints/standard/PatternConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/PatternConstraint.java
@@ -9,9 +9,10 @@ import graphql.validation.constraints.Documentation;
 import graphql.validation.rules.ValidationEnvironment;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -20,7 +21,7 @@ import static java.util.Collections.emptyList;
 
 public class PatternConstraint extends AbstractDirectiveConstraint {
 
-    private final static Map<String, Pattern> SEEN_PATTERNS = new HashMap<>();
+    private final static ConcurrentMap<String, Pattern> SEEN_PATTERNS = new ConcurrentHashMap<>();
 
     public PatternConstraint() {
         super("Pattern");


### PR DESCRIPTION
Porting change from https://github.com/graphql-java/graphql-java-extended-validation/pull/65 to hibernate validator 6.2.0 branch.