### PR TITLE
Use applied directives rather than directives by themselves

### DIFF
--- a/src/main/java/graphql/validation/constraints/standard/AbstractDecimalMinMaxConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/AbstractDecimalMinMaxConstraint.java
@@ -1,14 +1,16 @@
 package graphql.validation.constraints.standard;
 
 import graphql.GraphQLError;
-import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.validation.constraints.AbstractDirectiveConstraint;
 import graphql.validation.rules.ValidationEnvironment;
+
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+
 import static graphql.validation.constraints.GraphQLScalars.GRAPHQL_NUMBER_AND_STRING_TYPES;
 
 abstract class AbstractDecimalMinMaxConstraint extends AbstractDirectiveConstraint {
@@ -29,7 +31,7 @@ abstract class AbstractDecimalMinMaxConstraint extends AbstractDirectiveConstrai
     protected List<GraphQLError> runConstraint(ValidationEnvironment validationEnvironment) {
         Object validatedValue = validationEnvironment.getValidatedValue();
 
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
         String value = getStrArg(directive, "value");
         boolean inclusive = getBoolArg(directive, "inclusive");
 

--- a/src/main/java/graphql/validation/constraints/standard/AbstractMinMaxConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/AbstractMinMaxConstraint.java
@@ -1,12 +1,13 @@
 package graphql.validation.constraints.standard;
 
 import graphql.GraphQLError;
-import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.validation.constraints.AbstractDirectiveConstraint;
 import graphql.validation.constraints.GraphQLScalars;
 import graphql.validation.rules.ValidationEnvironment;
+
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +30,7 @@ abstract class AbstractMinMaxConstraint extends AbstractDirectiveConstraint {
     @Override
     protected List<GraphQLError> runConstraint(ValidationEnvironment validationEnvironment) {
         Object validatedValue = validationEnvironment.getValidatedValue();
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
         int value = getIntArg(directive, "value");
 
         boolean isOK;

--- a/src/main/java/graphql/validation/constraints/standard/AbstractSizeConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/AbstractSizeConstraint.java
@@ -1,10 +1,11 @@
 package graphql.validation.constraints.standard;
 
 import graphql.GraphQLError;
-import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLInputType;
 import graphql.validation.constraints.AbstractDirectiveConstraint;
 import graphql.validation.rules.ValidationEnvironment;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -18,7 +19,7 @@ public abstract class AbstractSizeConstraint extends AbstractDirectiveConstraint
         Object validatedValue = validationEnvironment.getValidatedValue();
         GraphQLInputType argType = validationEnvironment.getValidatedType();
 
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
         int min = getIntArg(directive, "min");
         int max = getIntArg(directive, "max");
 

--- a/src/main/java/graphql/validation/constraints/standard/DigitsConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/DigitsConstraint.java
@@ -1,14 +1,16 @@
 package graphql.validation.constraints.standard;
 
 import graphql.GraphQLError;
-import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLInputType;
 import graphql.validation.constraints.AbstractDirectiveConstraint;
 import graphql.validation.constraints.Documentation;
 import graphql.validation.rules.ValidationEnvironment;
+
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+
 import static graphql.validation.constraints.GraphQLScalars.GRAPHQL_NUMBER_AND_STRING_TYPES;
 
 public class DigitsConstraint extends AbstractDirectiveConstraint {
@@ -39,7 +41,7 @@ public class DigitsConstraint extends AbstractDirectiveConstraint {
     protected List<GraphQLError> runConstraint(ValidationEnvironment validationEnvironment) {
         Object validatedValue = validationEnvironment.getValidatedValue();
 
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
         int maxIntegerLength = getIntArg(directive, "integer");
         int maxFractionLength = getIntArg(directive, "fraction");
 

--- a/src/main/java/graphql/validation/constraints/standard/ExpressionConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/ExpressionConstraint.java
@@ -1,10 +1,7 @@
 package graphql.validation.constraints.standard;
 
 import graphql.GraphQLError;
-import graphql.schema.GraphQLDirective;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLFieldsContainer;
-import graphql.schema.GraphQLInputType;
+import graphql.schema.*;
 import graphql.validation.constraints.AbstractDirectiveConstraint;
 import graphql.validation.constraints.Documentation;
 import graphql.validation.el.ELSupport;
@@ -50,7 +47,7 @@ public class ExpressionConstraint extends AbstractDirectiveConstraint {
 
     @Override
     protected List<GraphQLError> runConstraint(ValidationEnvironment validationEnvironment) {
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
         String expression = helpWithCurlyBraces(getStrArg(directive, "value"));
 
         Map<String, Object> variables = StandardELVariables.standardELVars(validationEnvironment);

--- a/src/main/java/graphql/validation/constraints/standard/PatternConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/PatternConstraint.java
@@ -2,6 +2,7 @@ package graphql.validation.constraints.standard;
 
 import graphql.GraphQLError;
 import graphql.Scalars;
+import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLInputType;
 import graphql.validation.constraints.AbstractDirectiveConstraint;
@@ -47,7 +48,7 @@ public class PatternConstraint extends AbstractDirectiveConstraint {
 
         String strValue = String.valueOf(validatedValue);
 
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
 
         String patternArg = getStrArg(directive, "regexp");
         Pattern pattern = cachedPattern(patternArg);

--- a/src/main/java/graphql/validation/constraints/standard/RangeConstraint.java
+++ b/src/main/java/graphql/validation/constraints/standard/RangeConstraint.java
@@ -1,14 +1,16 @@
 package graphql.validation.constraints.standard;
 
 import graphql.GraphQLError;
-import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLInputType;
 import graphql.validation.constraints.AbstractDirectiveConstraint;
 import graphql.validation.constraints.Documentation;
 import graphql.validation.rules.ValidationEnvironment;
+
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+
 import static graphql.validation.constraints.GraphQLScalars.GRAPHQL_NUMBER_AND_STRING_TYPES;
 
 public class RangeConstraint extends AbstractDirectiveConstraint {
@@ -40,7 +42,7 @@ public class RangeConstraint extends AbstractDirectiveConstraint {
     protected List<GraphQLError> runConstraint(ValidationEnvironment validationEnvironment) {
         Object validatedValue = validationEnvironment.getValidatedValue();
 
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
         BigDecimal min = asBigDecimal(getIntArg(directive, "min"));
         BigDecimal max = asBigDecimal(getIntArg(directive, "max"));
 

--- a/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
+++ b/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
@@ -4,20 +4,9 @@ import graphql.ErrorClassification;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
 import graphql.execution.ResultPath;
-import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLAppliedDirective;
 import graphql.validation.el.StandardELVariables;
 import graphql.validation.rules.ValidationEnvironment;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-import java.util.LinkedHashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.MissingResourceException;
-import java.util.Optional;
-import java.util.ResourceBundle;
-import jakarta.validation.Constraint;
-import jakarta.validation.Path;
-import jakarta.validation.Payload;
 import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
@@ -27,12 +16,15 @@ import org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDesc
 import org.hibernate.validator.messageinterpolation.ExpressionLanguageFeatureLevel;
 import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Path;
+import jakarta.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.*;
+
+import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -70,7 +62,7 @@ public class ResourceBundleMessageInterpolator implements MessageInterpolator {
     @SuppressWarnings("unused")
     protected ErrorClassification buildErrorClassification(String messageTemplate, Map<String, Object> messageParams, ValidationEnvironment validationEnvironment) {
         ResultPath fieldOrArgumentPath = validationEnvironment.getValidatedPath();
-        GraphQLDirective directive = validationEnvironment.getContextObject(GraphQLDirective.class);
+        GraphQLAppliedDirective directive = validationEnvironment.getContextObject(GraphQLAppliedDirective.class);
         return new ValidationErrorType(fieldOrArgumentPath, directive);
     }
 
@@ -183,9 +175,9 @@ public class ResourceBundleMessageInterpolator implements MessageInterpolator {
 
     private static class ValidationErrorType implements ErrorClassification {
         private final ResultPath fieldOrArgumentPath;
-        private final GraphQLDirective directive;
+        private final GraphQLAppliedDirective directive;
 
-        ValidationErrorType(ResultPath fieldOrArgumentPath, GraphQLDirective directive) {
+        ValidationErrorType(ResultPath fieldOrArgumentPath, GraphQLAppliedDirective directive) {
             this.fieldOrArgumentPath = fieldOrArgumentPath;
             this.directive = directive;
         }

--- a/src/main/java/graphql/validation/rules/TargetedValidationRules.java
+++ b/src/main/java/graphql/validation/rules/TargetedValidationRules.java
@@ -4,17 +4,7 @@ import graphql.Assert;
 import graphql.GraphQLError;
 import graphql.PublicApi;
 import graphql.execution.ResultPath;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLDirective;
-import graphql.schema.GraphQLDirectiveContainer;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLInputObjectField;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.*;
 import graphql.util.FpKit;
 import graphql.validation.interpolation.MessageInterpolator;
 import graphql.validation.locale.LocaleUtil;
@@ -112,7 +102,7 @@ public class TargetedValidationRules {
                     .validatedType(inputType)
                     .validatedValue(argValue)
                     .validatedPath(fieldPath.segment(fieldArg.getName()))
-                    .directives(fieldArg.getDirectives())
+                    .directives(fieldArg.getAppliedDirectives())
                     .messageInterpolator(interpolator)
                     .locale(defaultLocale)
                     .build();
@@ -173,7 +163,7 @@ public class TargetedValidationRules {
                     .validatedPath(newPath)
                     .validatedValue(validatedValue)
                     .validatedType(fieldType)
-                    .directives(inputField.getDirectives())
+                    .directives(inputField.getAppliedDirectives())
                     .validatedElement(INPUT_OBJECT_FIELD)
             );
 
@@ -187,11 +177,11 @@ public class TargetedValidationRules {
         List<GraphQLError> errors = new ArrayList<>();
 
         GraphQLInputType listItemType = Util.unwrapOneAndAllNonNull(argumentType);
-        List<GraphQLDirective> directives;
+        List<GraphQLAppliedDirective> directives;
         if (!(listItemType instanceof GraphQLDirectiveContainer)) {
             directives = Collections.emptyList();
         } else {
-            directives = ((GraphQLDirectiveContainer) listItemType).getDirectives();
+            directives = ((GraphQLDirectiveContainer) listItemType).getAppliedDirectives();
         }
         int ix = 0;
         for (Object value : objectList) {

--- a/src/main/java/graphql/validation/rules/ValidationEnvironment.java
+++ b/src/main/java/graphql/validation/rules/ValidationEnvironment.java
@@ -3,12 +3,7 @@ package graphql.validation.rules;
 import graphql.PublicApi;
 import graphql.execution.ResultPath;
 import graphql.language.SourceLocation;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLDirective;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLFieldsContainer;
-import graphql.schema.GraphQLInputType;
+import graphql.schema.*;
 import graphql.validation.interpolation.MessageInterpolator;
 
 import java.util.Collections;
@@ -55,7 +50,7 @@ public class ValidationEnvironment {
     private final Object validatedValue;
     private final GraphQLInputType validatedType;
     private final ValidatedElement validatedElement;
-    private final List<GraphQLDirective> directives;
+    private final List<GraphQLAppliedDirective> directives;
 
     private ValidationEnvironment(Builder builder) {
         this.argument = builder.argument;
@@ -131,7 +126,7 @@ public class ValidationEnvironment {
         return validatedElement;
     }
 
-    public List<GraphQLDirective> getDirectives() {
+    public List<GraphQLAppliedDirective> getDirectives() {
         return directives;
     }
 
@@ -155,7 +150,7 @@ public class ValidationEnvironment {
         private Object validatedValue;
         private GraphQLInputType validatedType;
         private ValidatedElement validatedElement;
-        private List<GraphQLDirective> directives = Collections.emptyList();
+        private List<GraphQLAppliedDirective> directives = Collections.emptyList();
 
         public Builder validationEnvironment(ValidationEnvironment validationEnvironment) {
             this.argument = validationEnvironment.argument;
@@ -176,9 +171,9 @@ public class ValidationEnvironment {
         }
 
         public Builder dataFetchingEnvironment(DataFetchingEnvironment dataFetchingEnvironment) {
-            fieldsContainer(dataFetchingEnvironment.getExecutionStepInfo().getFieldContainer());
+            fieldsContainer(dataFetchingEnvironment.getExecutionStepInfo().getObjectType());
             fieldDefinition(dataFetchingEnvironment.getFieldDefinition());
-            directives(dataFetchingEnvironment.getFieldDefinition().getDirectives());
+            directives(dataFetchingEnvironment.getFieldDefinition().getAppliedDirectives());
             executionPath(dataFetchingEnvironment.getExecutionStepInfo().getPath());
             validatedPath(dataFetchingEnvironment.getExecutionStepInfo().getPath());
             location(dataFetchingEnvironment.getField().getSourceLocation());
@@ -252,7 +247,7 @@ public class ValidationEnvironment {
             return this;
         }
 
-        public Builder directives(List<GraphQLDirective> directives) {
+        public Builder directives(List<GraphQLAppliedDirective> directives) {
             this.directives = directives;
             return this;
         }

--- a/src/main/java/graphql/validation/util/DirectivesAndTypeWalker.java
+++ b/src/main/java/graphql/validation/util/DirectivesAndTypeWalker.java
@@ -1,14 +1,7 @@
 package graphql.validation.util;
 
 import graphql.Internal;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLDirective;
-import graphql.schema.GraphQLDirectiveContainer;
-import graphql.schema.GraphQLInputObjectField;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLTypeUtil;
+import graphql.schema.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -20,16 +13,16 @@ public class DirectivesAndTypeWalker {
 
     private final Map<String, Boolean> seenTypes = new HashMap<>();
 
-    public boolean isSuitable(GraphQLArgument argument, BiFunction<GraphQLInputType, GraphQLDirective, Boolean> isSuitable) {
+    public boolean isSuitable(GraphQLArgument argument, BiFunction<GraphQLInputType, GraphQLAppliedDirective, Boolean> isSuitable) {
         GraphQLInputType inputType = argument.getType();
-        List<GraphQLDirective> directives = argument.getDirectives();
+        List<GraphQLAppliedDirective> directives = argument.getAppliedDirectives();
         return walkInputType(inputType, directives, isSuitable);
     }
 
-    private boolean walkInputType(GraphQLInputType inputType, List<GraphQLDirective> directives, BiFunction<GraphQLInputType, GraphQLDirective, Boolean> isSuitable) {
+    private boolean walkInputType(GraphQLInputType inputType, List<GraphQLAppliedDirective> directives, BiFunction<GraphQLInputType, GraphQLAppliedDirective, Boolean> isSuitable) {
         String typeName = GraphQLTypeUtil.unwrapAll(inputType).getName();
         GraphQLInputType unwrappedInputType = Util.unwrapNonNull(inputType);
-        for (GraphQLDirective directive : directives) {
+        for (GraphQLAppliedDirective directive : directives) {
             if (isSuitable.apply(unwrappedInputType, directive)) {
                 return seen(typeName,true);
             }
@@ -43,7 +36,7 @@ public class DirectivesAndTypeWalker {
 
             for (GraphQLInputObjectField inputField : inputObjType.getFieldDefinitions()) {
                 inputType = inputField.getType();
-                directives = inputField.getDirectives();
+                directives = inputField.getAppliedDirectives();
 
                 if (walkInputType(inputType, directives, isSuitable)) {
                     return seen(typeName,true);
@@ -53,7 +46,7 @@ public class DirectivesAndTypeWalker {
         if (unwrappedInputType instanceof GraphQLList) {
             GraphQLInputType innerListType = Util.unwrapOneAndAllNonNull(unwrappedInputType);
             if (innerListType instanceof GraphQLDirectiveContainer) {
-                directives = ((GraphQLDirectiveContainer) innerListType).getDirectives();
+                directives = ((GraphQLDirectiveContainer) innerListType).getAppliedDirectives();
                 if (walkInputType(innerListType, directives, isSuitable)) {
                     return seen(typeName,true);
                 }

--- a/src/test/groovy/ELDiscover.java
+++ b/src/test/groovy/ELDiscover.java
@@ -3,9 +3,6 @@ import jakarta.el.ELManager;
 import jakarta.el.ExpressionFactory;
 import jakarta.el.StandardELContext;
 import jakarta.el.ValueExpression;
-import jakarta.validation.MessageInterpolator;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Range;
 import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
 import org.hibernate.validator.internal.engine.path.PathImpl;
@@ -17,6 +14,9 @@ import org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDesc
 import org.hibernate.validator.messageinterpolation.ExpressionLanguageFeatureLevel;
 import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
 
+import jakarta.validation.MessageInterpolator;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/test/groovy/graphql/validation/TestUtil.groovy
+++ b/src/test/groovy/graphql/validation/TestUtil.groovy
@@ -15,6 +15,7 @@ import graphql.language.Type
 import graphql.parser.Parser
 import graphql.schema.Coercing
 import graphql.schema.DataFetcher
+import graphql.schema.GraphQLAppliedDirective
 import graphql.schema.GraphQLArgument
 import graphql.schema.GraphQLDirective
 import graphql.schema.GraphQLFieldDefinition
@@ -189,8 +190,8 @@ class TestUtil {
                 definition)
     }
 
-    static GraphQLDirective mockDirective(String name) {
-        new GraphQLDirective(name, name, EnumSet.noneOf(DirectiveLocation.class), Collections.emptyList(), false, false, false)
+    static GraphQLAppliedDirective mockDirective(String name) {
+        new GraphQLAppliedDirective(name, name, EnumSet.noneOf(DirectiveLocation.class), Collections.emptyList(), false, false, false)
     }
 
     static TypeRuntimeWiring mockTypeRuntimeWiring(String typeName, boolean withResolver) {

--- a/src/test/groovy/graphql/validation/constraints/BaseConstraintTestSupport.groovy
+++ b/src/test/groovy/graphql/validation/constraints/BaseConstraintTestSupport.groovy
@@ -2,18 +2,12 @@ package graphql.validation.constraints
 
 import graphql.GraphQLError
 import graphql.GraphqlErrorBuilder
-import graphql.execution.ResultPath
 import graphql.execution.ExecutionStepInfo
 import graphql.execution.MergedField
+import graphql.execution.ResultPath
 import graphql.language.Field
 import graphql.language.SourceLocation
-import graphql.schema.DataFetchingEnvironmentImpl
-import graphql.schema.GraphQLArgument
-import graphql.schema.GraphQLDirective
-import graphql.schema.GraphQLFieldDefinition
-import graphql.schema.GraphQLFieldsContainer
-import graphql.schema.GraphQLObjectType
-import graphql.schema.GraphQLSchema
+import graphql.schema.*
 import graphql.validation.TestUtil
 import graphql.validation.interpolation.MessageInterpolator
 import graphql.validation.rules.TargetedValidationRules
@@ -102,7 +96,7 @@ class BaseConstraintTestSupport extends Specification {
                 .fieldsContainer(fieldsContainer)
                 .executionPath(ResultPath.rootPath().segment(fieldDefinition.getName()))
                 .validatedPath(ResultPath.rootPath().segment(argName))
-                .context(GraphQLDirective.class, argUnderTest.getDirective(targetDirective))
+                .context(GraphQLAppliedDirective.class, argUnderTest.getAppliedDirective(targetDirective))
                 .messageInterpolator(interpolator)
                 .build()
         ruleEnvironment
@@ -120,8 +114,8 @@ class BaseConstraintTestSupport extends Specification {
                 .executionPath(path)
                 .validatedElement(ValidationEnvironment.ValidatedElement.FIELD)
                 .validatedPath(path)
-                .directives(fieldDefinition.getDirectives())
-                .context(GraphQLDirective.class, fieldDefinition.getDirective(targetDirective.name))
+                .directives(fieldDefinition.getAppliedDirectives())
+                .context(GraphQLAppliedDirective.class, fieldDefinition.getAppliedDirective(targetDirective.name))
                 .messageInterpolator(interpolator)
                 .build()
         ruleEnvironment


### PR DESCRIPTION
Update to use the new `AppliedDirectives` instead of the old `Directive`. 

This seems to break when upgrading to graphql-java 19, and it does still work for graphql-java 18.