### PR TITLE
Update graphql-java to 19.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ This library provides extended validation of fields and field arguments for [gra
 <dependency>
   <groupId>com.graphql-java</groupId>
   <artifactId>graphql-java-extended-validation</artifactId>
-  <version>18.1</version>
+  <version>19.0</version>
 </dependency>
 ```
 
 ```groovy
-compile 'com.graphql-java:graphql-java-extended-validation:18.1'
+compile 'com.graphql-java:graphql-java-extended-validation:19.0'
 ```
 
 > Note:
@@ -38,6 +38,8 @@ compile 'com.graphql-java:graphql-java-extended-validation:18.1'
 > use 18.1 or above for graphql-java 18.x and above
 >
 > use 18.1-hibernate-validator-6.2.0.Final for graphql-java 18.x and SpringBoot 2.x support
+>
+> use 19.0 or above for graphql-java 19.x and above
 
 It's currently available from Maven central.
 
@@ -134,14 +136,13 @@ Like javax.validation, this library ships with some default error message templa
 # I18n Locale Support
 
 The validation library aims to offer Internationalisation (18N) of the error messages.  When the validation rules
-run they are passed in a `java.util.Locale`.  A `ResourceBundleMessageInterpolator` can then be used to build up messages
+run they are passed in a `java.util.Locale`. A `ResourceBundleMessageInterpolator` can then be used to build up messages
 that come from I18N bundles.
 
-A `Locale` should be created per graphql execution.  However at the time of writing graphql-java does not
-pass in a `Locale` per request `ExecutionInput` .  A PR exists to fix this and it will be released in v14.0.  This
-library will then be updated to to take advantage of this.  
+A `Locale` should be created per graphql execution, and can be passed to `ExecutionInput`. More i18n is being added to graphql-java 
+and later this library will then be updated to to take advantage of i18n.  
 
-In the mean time you can work around this by having the `context`, `source` or `root` implement `graphql.validation.locale.LocaleProvider` and
+In the meantime you can work around this by having the `context`, `source` or `root` implement `graphql.validation.locale.LocaleProvider` and
 the library will extract a `Locale` from that.
 
 # Schema Directive Wiring

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,12 @@ version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 println "Building version = " + version
 group = 'com.graphql-java'
 
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+    def msg = String.format("This build must be run with java 1.8 - you are running %s - gradle finds the JDK via JAVA_HOME=%s",
+            JavaVersion.current(), System.getenv("JAVA_HOME"))
+    throw new GradleException(msg)
+}
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
@@ -39,8 +45,8 @@ repositories {
 
 
 dependencies {
-    api "com.graphql-java:graphql-java:18.1"
-    api "com.graphql-java:graphql-java-extended-scalars:18.1"
+    api "com.graphql-java:graphql-java:19.2"
+    api "com.graphql-java:graphql-java-extended-scalars:19.0"
     api "org.hibernate.validator:hibernate-validator:7.0.1.Final"
     api "org.glassfish:jakarta.el:4.0.0"
 


### PR DESCRIPTION
Getting ready for a v19 release. v19.0 of graphql-java is one of the versions containing the patch for CVE-2022-37734 https://www.cve.org/CVERecord?id=CVE-2022-37734