### PR TITLE
Upgrade to Java 11

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: '8.0.282'
+          java-version: '11.0.17'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: '8.0.282'
+          java-version: '11.0.17'
       - name: build and test
         run: ./gradlew assemble && ./gradlew check --info --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: '8.0.282'
+          java-version: '11.0.17'
       - name: build test and publish
         run: ./gradlew assemble && ./gradlew check --info && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -x check --info --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,14 @@ version = releaseVersion ? releaseVersion : getDevelopmentVersion()
 println "Building version = " + version
 group = 'com.graphql-java'
 
-if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-    def msg = String.format("This build must be run with java 1.8 - you are running %s - gradle finds the JDK via JAVA_HOME=%s",
+if (JavaVersion.current() != JavaVersion.VERSION_11) {
+    def msg = String.format("This build must be run with Java 11 - you are running %s - gradle finds the JDK via JAVA_HOME=%s",
             JavaVersion.current(), System.getenv("JAVA_HOME"))
     throw new GradleException(msg)
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_11.toString()
+targetCompatibility = JavaVersion.VERSION_11.toString()
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Update to Java 11 as future versions of graphql-java will require 11 as a minimum https://www.graphql-java.com/blog/java-11-required