### PR TITLE
Update graphql-java to v20 for special validator 6.2.0.final release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - master
       - v19.x-validator-6.2.0.Final
+      - v20.x-validator-6.2.0.Final
 jobs:
   buildAndTest:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ repositories {
 
 
 dependencies {
-    api "com.graphql-java:graphql-java:19.2"
-    api "com.graphql-java:graphql-java-extended-scalars:19.0"
+    api "com.graphql-java:graphql-java:20.0"
+    api "com.graphql-java:graphql-java-extended-scalars:20.0"
     api "org.hibernate.validator:hibernate-validator:6.2.0.Final"
     api "org.glassfish:jakarta.el:3.0.4"
 


### PR DESCRIPTION
This is for a special release with a downgraded Hibernate Validator version. See https://github.com/graphql-java/graphql-java-extended-validation/issues/52 for further discussion