### PR TITLE
Prepend 0.0.0 to master build versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ def getDevelopmentVersion() {
         println "git hash is empty: error: ${error.toString()}"
         throw new IllegalStateException("git hash could not be determined")
     }
-    new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
+    "0.0.0-" + new SimpleDateFormat('yyyy-MM-dd\'T\'HH-mm-ss').format(new Date()) + "-" + gitHash
 }
 
 


### PR DESCRIPTION
This is to ensure master build versions don't appear as the "latest" release version in Maven, when sorting in descending order. We have prepended `0.0.0` to builds in graphql-java for a while now.