### PR TITLE
Retain trivial DataFetcher marker when original DataFetcher was trivial

### DIFF
--- a/src/main/java/graphql/validation/schemawiring/TrivialFieldValidatorDataFetcher.java
+++ b/src/main/java/graphql/validation/schemawiring/TrivialFieldValidatorDataFetcher.java
@@ -1,0 +1,15 @@
+package graphql.validation.schemawiring;
+
+import graphql.TrivialDataFetcher;
+import graphql.schema.DataFetcher;
+import graphql.validation.interpolation.MessageInterpolator;
+import graphql.validation.rules.OnValidationErrorStrategy;
+import graphql.validation.rules.ValidationRules;
+
+import java.util.Locale;
+
+public class TrivialFieldValidatorDataFetcher extends FieldValidatorDataFetcher implements TrivialDataFetcher<Object> {
+    public TrivialFieldValidatorDataFetcher(OnValidationErrorStrategy errorStrategy, MessageInterpolator messageInterpolator, DataFetcher<?> defaultDataFetcher, Locale defaultLocale, ValidationRules validationRules) {
+        super(errorStrategy, messageInterpolator, defaultDataFetcher, defaultLocale, validationRules);
+    }
+}

--- a/src/main/java/graphql/validation/schemawiring/ValidationSchemaWiring.java
+++ b/src/main/java/graphql/validation/schemawiring/ValidationSchemaWiring.java
@@ -1,6 +1,7 @@
 package graphql.validation.schemawiring;
 
 import graphql.PublicApi;
+import graphql.TrivialDataFetcher;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLFieldsContainer;
@@ -8,7 +9,6 @@ import graphql.schema.idl.SchemaDirectiveWiring;
 import graphql.schema.idl.SchemaDirectiveWiringEnvironment;
 import graphql.validation.interpolation.MessageInterpolator;
 import graphql.validation.rules.OnValidationErrorStrategy;
-import graphql.validation.rules.TargetedValidationRules;
 import graphql.validation.rules.ValidationRules;
 
 import java.util.Locale;
@@ -51,6 +51,16 @@ public class ValidationSchemaWiring implements SchemaDirectiveWiring {
                                                            MessageInterpolator messageInterpolator,
                                                            DataFetcher<?> currentDF,
                                                            final Locale defaultLocale) {
+        if (currentDF instanceof TrivialDataFetcher) {
+           return new TrivialFieldValidatorDataFetcher(
+                   errorStrategy,
+                   messageInterpolator,
+                   currentDF,
+                   defaultLocale,
+                   ruleCandidates
+           );
+        }
+        
         return new FieldValidatorDataFetcher(
                 errorStrategy,
                 messageInterpolator,


### PR DESCRIPTION
Resolve #87 - Create a TrivialFieldValidatorDataFetcher which extends FieldValidatorDataFetcher **and implements TrivialDataFetcher** instead of a standard FieldValidatorDataFetcher if the original dataFetcher was an instance of TrivialDataFetcher.