### PR TITLE
Add parameters from validation directives as el expression variables

### DIFF
--- a/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
+++ b/src/main/java/graphql/validation/interpolation/ResourceBundleMessageInterpolator.java
@@ -156,6 +156,7 @@ public class ResourceBundleMessageInterpolator implements MessageInterpolator {
         );
 
         Map<String, Object> expressionVariables = StandardELVariables.standardELVars(validationEnvironment);
+        expressionVariables.putAll(messageParams);
 
         Class<?> rootBeanType = null;
         Path propertyPath = null;

--- a/src/test/groovy/graphql/validation/interpolation/ResourceBundleMessageInterpolatorTest.groovy
+++ b/src/test/groovy/graphql/validation/interpolation/ResourceBundleMessageInterpolatorTest.groovy
@@ -51,7 +51,7 @@ class ResourceBundleMessageInterpolatorTest extends Specification {
         def interpolatorUnderTest = new ResourceBundleMessageInterpolator()
 
         def validatedValue = [zig: "zag"]
-        def messageParams = ["validatedValue": validatedValue, "p1": "pv1", "p2": "pv2", "min": "5", "max": "10", path : "a/b/c"]
+        def messageParams = ["validatedValue": validatedValue, "p1": "pv1", "p2": "pv2", "min": "5", "max": "10", path : "a/b/c", "value" : "100", "inclusive" : true]
         ValidationEnvironment validationEnvironment = buildEnv(schema, "arg", validatedValue, interpolatorUnderTest, null)
 
         expect:
@@ -66,6 +66,8 @@ class ResourceBundleMessageInterpolatorTest extends Specification {
         'graphql.test.message'            | 'Test message with expressions : zag and replacements : pv1'
         // system level message finding from graphql.validation
         'graphql.validation.Size.message' | 'a/b/c size must be between 5 and 10'
+        // message with el expression
+        'graphql.validation.DecimalMax.message' | 'a/b/c must be less than or equal to 100'
         // expressions
         'Could not ${validatedValue.zig}' | 'Could not zag'
         // message param replacement


### PR DESCRIPTION
Addressing https://github.com/graphql-java/graphql-java-extended-validation/issues/61

`MessageInterpolatorContext.messageParameters` are not being used in `hibernate-validator` `ElTermResolver`, only `ExpressionVariables` are.
https://github.com/hibernate/hibernate-validator/blob/7ad950b3274ef42e2f58d538e774588d6a9ba46e/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/ElTermResolver.java#L132-L137